### PR TITLE
Fixes in image and region names. Added token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ Setup
 =====
 
 * Install [Vagrant](http://www.vagrantup.com/downloads.html)
-* execute `vagrant plugin install vagrant-digitalocean-omnibus vagrant-digitalocean`
+* execute `vagrant plugin install vagrant-omnibus vagrant-digitalocean`
 * sign up for your favorite supported hoster
 * set up environment-variables: 
   * For Digitalocean: 
     ```bash
     export DIGITALOCEAN_CLIENT_ID="<TODO>"
     export DIGITALOCEAN_API_KEY="<TODO>"
+    // or Personal Access Tokens instead
+    export DIGITALOCEAN_TOKEN="<TODO>"
     ```
 
   * For Rackspace: 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,8 +8,9 @@ Vagrant.configure('2') do |config|
 
     provider.client_id = ENV["DIGITALOCEAN_CLIENT_ID"]
     provider.api_key = ENV["DIGITALOCEAN_API_KEY"]
-    provider.region = 'New York 3'
-    provider.image = '7.0 x64'
+    provider.token = ENV["DIGITALOCEAN_TOKEN"]
+    provider.region = 'nyc3'
+    provider.image = 'debian-7-0-x64'
   end
 
   config.vm.provider :rackspace do |rs, override|


### PR DESCRIPTION
1) For me digital ocean doesn't work for current image name and region name, so I switched it to slug name. Maybe it depends of plugin version or so (or maybe it depends of 2). Error:

```
Contained no object with the value "7.0 x64" for the the
key "slug".

Please ensure that the configured value exists in the collection.
```

 2) Digital ocean provider supports personal token, so you may use it in case not create new application.
 3) `vagrant-digitalocean-omnibus` looks like small mistake, it should be `vagrant-omnibus` I guess.

Thanks.
